### PR TITLE
Fixed parsing of duoferncode. 

### DIFF
--- a/main.js
+++ b/main.js
@@ -389,7 +389,7 @@ function createStates(result, i) {
     });
 	
 	if (duoferncode.substring(0,2) == "43" || duoferncode.substring(0,2) == "46" || 
-		(parseInt(duoferncode.substring(0,2)) < 20 && product.indexOf('Repeater') != -1)) {
+		(parseInt(duoferncode.substring(0,2), 16) < 26 && product.indexOf('Repeater') != -1)) {
         adapter.setObjectNotExists(path + '.state', {
             type: 'state',
             common: {
@@ -411,7 +411,7 @@ function createStates(result, i) {
                 });
             }
         });
-    } else if (parseInt(duoferncode.substring(0,2)) < 20 && product.indexOf('Repeater') == -1) { // HeizkörperstellantrieZ-Wave
+    } else if (parseInt(duoferncode.substring(0,2),16) < 26 && product.indexOf('Repeater') == -1) { // HeizkörperstellantrieZ-Wave
        adapter.setObjectNotExists(path + '.temperature', {
           type: 'state',
             common: {
@@ -557,13 +557,13 @@ function writeStates(result, i) {
     });
     // STATE
     if (duoferncode.substring(0,2) == "43" || duoferncode.substring(0,2) == "46" ||
-		(parseInt(duoferncode.substring(0,2)) < 20 && product.indexOf('Repeater') != -1)) { 
+		(parseInt(duoferncode.substring(0,2), 16) < 26 && product.indexOf('Repeater') != -1)) { 
         var statevalue = (result.devices[i].position == 100 || result.devices[i].position === '100') ? true : false;
         adapter.setState(path + 'state', {
             val: statevalue,
             ack: true
         }); // maybe should write to adapters level and level_inverted too
-	} else if (parseInt(duoferncode.substring(0,2)) < 20 && product.indexOf('Repeater') == -1) { // HeizkörperstellantrieZ-Wave
+	} else if (parseInt(duoferncode.substring(0,2), 16) < 26 && product.indexOf('Repeater') == -1) { // HeizkörperstellantrieZ-Wave
 		// TEMP
         adapter.setState(path + 'temperature', {
             val: (parseFloat(result.devices[i].position) * 0.1),


### PR DESCRIPTION
The following code assumed the duoferncode to be an integer:
`parseInt(duoferncode.substring(0,2)) < 20`
This must be wrong as the Connect Aktor has the code "4B".
Therefore, no level state was created for those devices but a temperature state was there instead (with a scaling of 0.1°C <=> 1%).
I fixed this by exchanging the above code with
`parseInt(duoferncode.substring(0,2), 16) < 26`
With the fix (which I tested locally by replacing main.js,) the level and level_inverted states were created correctly and the right information is shown (0%/100%).

